### PR TITLE
[18.0][FIX] stock_storage_type: AttributeError: estimated_pack_weight_kg

### DIFF
--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -14,6 +14,8 @@
     "application": False,
     "installable": True,
     "depends": [
+        # odoo
+        "stock_delivery",
         # OCA/stock-logistics-tracking
         "stock_quant_package_dimension",
         # OCA/stock-logistics-warehouse

--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -14,8 +14,6 @@
     "application": False,
     "installable": True,
     "depends": [
-        # odoo
-        "stock_delivery",
         # OCA/stock-logistics-tracking
         "stock_quant_package_dimension",
         # OCA/stock-logistics-warehouse

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -524,10 +524,9 @@ class StockLocation(models.Model):
                     quants.package_id.height_in_m,
                 ),
             ]
-        package_weight_kg = (
-            quants.package_id.pack_weight_in_kg
-            or quants.package_id.estimated_pack_weight_kg
-        )
+        package_weight_kg = quants.package_id.pack_weight_in_kg
+        if not package_weight_kg and quants.package_id.weight_is_kg:
+            package_weight_kg = quants.package_id.weight
         if package_weight_kg:
             pertinent_category_domain += [
                 "|",

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -525,14 +525,14 @@ class StockLocation(models.Model):
                 ),
             ]
         package = quants.package_id
-        package_weight_kg = package.pack_weight_in_kg or package.sudo()._get_weight(
-            self.env.context.get("picking_id")
-        ).get(package)
-        if package_weight_kg:
+        weight = (
+            package.sudo()._get_weight(self.env.context.get("picking_id")).get(package)
+        )
+        if weight:
             pertinent_category_domain += [
                 "|",
                 ("max_weight_in_kg", "=", 0),
-                ("max_weight_in_kg", ">=", package_weight_kg),
+                ("max_weight_in_kg", ">=", weight),
             ]
         _logger.debug(
             "pertinent storage category domain: %s", pertinent_category_domain

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -524,9 +524,10 @@ class StockLocation(models.Model):
                     quants.package_id.height_in_m,
                 ),
             ]
-        package_weight_kg = quants.package_id.pack_weight_in_kg
-        if not package_weight_kg and quants.package_id.weight_is_kg:
-            package_weight_kg = quants.package_id.weight
+        package = quants.package_id
+        package_weight_kg = package.pack_weight_in_kg or package.sudo()._get_weight(
+            self.env.context.get("picking_id")
+        ).get(package)
         if package_weight_kg:
             pertinent_category_domain += [
                 "|",

--- a/stock_storage_type/models/stock_quant.py
+++ b/stock_storage_type/models/stock_quant.py
@@ -32,9 +32,11 @@ class StockQuant(models.Model):
                     ).format(storage=package_type.name, location=location.name)
                 )
             package = quant.package_id
-            package_weight_kg = package.pack_weight_in_kg or package.sudo()._get_weight(
-                self.env.context.get("picking_id")
-            ).get(package)
+            weight = (
+                package.sudo()
+                ._get_weight(self.env.context.get("picking_id"))
+                .get(package)
+            )
             package_quants = quant.package_id.mapped("quant_ids")
             package_products = package_quants.mapped("product_id")
             package_lots = package_quants.mapped("lot_id")
@@ -95,18 +97,15 @@ class StockQuant(models.Model):
                     max_h=category.max_height_in_m,
                     height=quant.package_id.height_in_m,
                 )
-            elif (
-                category.max_weight_in_kg
-                and package_weight_kg > category.max_weight_in_kg
-            ):
+            elif category.max_weight_in_kg and weight > category.max_weight_in_kg:
                 error = _(
                     "Storage Category {category} defines "
                     "max weight of {max_w} but the package is heavier: "
-                    "{weight_kg}."
+                    "{weight}."
                 ).format(
                     category=category.display_name,
                     max_w=category.max_weight_in_kg,
-                    weight_kg=package_weight_kg,
+                    weight=weight,
                 )
             # If we get here, it means there is a storage category
             #  allowing the package into the location

--- a/stock_storage_type/models/stock_quant.py
+++ b/stock_storage_type/models/stock_quant.py
@@ -31,9 +31,10 @@ class StockQuant(models.Model):
                         "Location {location}"
                     ).format(storage=package_type.name, location=location.name)
                 )
-            package_weight_kg = quant.package_id.pack_weight_in_kg
-            if not package_weight_kg and quant.package_id.weight_is_kg:
-                package_weight_kg = quant.package_id.weight
+            package = quant.package_id
+            package_weight_kg = package.pack_weight_in_kg or package.sudo()._get_weight(
+                self.env.context.get("picking_id")
+            ).get(package)
             package_quants = quant.package_id.mapped("quant_ids")
             package_products = package_quants.mapped("product_id")
             package_lots = package_quants.mapped("lot_id")

--- a/stock_storage_type/models/stock_quant.py
+++ b/stock_storage_type/models/stock_quant.py
@@ -31,10 +31,9 @@ class StockQuant(models.Model):
                         "Location {location}"
                     ).format(storage=package_type.name, location=location.name)
                 )
-            package_weight_kg = (
-                quant.package_id.pack_weight_in_kg
-                or quant.package_id.estimated_pack_weight_kg
-            )
+            package_weight_kg = quant.package_id.pack_weight_in_kg
+            if not package_weight_kg and quant.package_id.weight_is_kg:
+                package_weight_kg = quant.package_id.weight
             package_quants = quant.package_id.mapped("quant_ids")
             package_products = package_quants.mapped("product_id")
             package_lots = package_quants.mapped("lot_id")

--- a/stock_storage_type/models/stock_quant_package.py
+++ b/stock_storage_type/models/stock_quant_package.py
@@ -7,26 +7,11 @@ from odoo.exceptions import ValidationError
 class StockQuantPackage(models.Model):
     _inherit = "stock.quant.package"
 
-    pack_weight_in_kg = fields.Float(
-        help="Technical field, to speed up comparaisons",
-        compute="_compute_pack_weight_in_kg",
-        store=True,
-    )
     height_in_m = fields.Float(
         help="Technical field, to speed up comparaisons",
         compute="_compute_height_in_m",
         store=True,
     )
-
-    @api.depends("pack_weight", "weight_uom_id")
-    def _compute_pack_weight_in_kg(self):
-        uom_kg = self.env.ref("uom.product_uom_kgm")
-        for package in self:
-            package.pack_weight_in_kg = package.weight_uom_id._compute_quantity(
-                qty=package.pack_weight,
-                to_unit=uom_kg,
-                round=False,
-            )
 
     @api.depends("height", "length_uom_id")
     def _compute_height_in_m(self):

--- a/stock_storage_type/models/stock_storage_category.py
+++ b/stock_storage_type/models/stock_storage_category.py
@@ -10,7 +10,6 @@ class StockStorageCategory(models.Model):
         selection_add=[("same_lot", "If lots are all the same")],
         ondelete={"same_lot": "cascade"},
     )
-
     computed_location_ids = fields.One2many(
         comodel_name="stock.location", inverse_name="computed_storage_category_id"
     )
@@ -19,17 +18,25 @@ class StockStorageCategory(models.Model):
         inverse_name="storage_category_id",
         string="Allow New Product Rules",
     )
-
-    # TODO: Move these fields in another module ?
     max_height = fields.Float(
         string="Max height (mm)",
         help="The max height supported for this storage category.",
     )
-
     max_height_in_m = fields.Float(
         help="Technical field, to speed up comparaisons",
         compute="_compute_max_height_in_m",
         store=True,
+    )
+    height_uom_id = fields.Many2one(
+        "uom.uom",
+        "Height Units of Measure",
+        domain=lambda self: [
+            ("category_id", "=", self.env.ref("uom.uom_categ_length").id)
+        ],
+        help="UoM for height",
+        default=lambda self: self.env[
+            "product.template"
+        ]._get_length_uom_id_from_ir_config_parameter(),
     )
     weight_uom_id = fields.Many2one(
         # Same as product.packing
@@ -44,12 +51,6 @@ class StockStorageCategory(models.Model):
             "product.template"
         ]._get_weight_uom_id_from_ir_config_parameter(),
     )
-    weight_uom_name = fields.Char(
-        # Same as product.packing
-        string="Weight unit of measure label",
-        related="weight_uom_id.name",
-        readonly=True,
-    )
     max_weight_in_kg = fields.Float(
         help="Technical field, to speed up comparaisons",
         compute="_compute_max_weight_in_kg",
@@ -58,11 +59,11 @@ class StockStorageCategory(models.Model):
     length_uom_id = fields.Many2one(
         # Same as product.packing
         "uom.uom",
-        "Dimensions Units of Measure",
+        "Length Units of Measure",
         domain=lambda self: [
             ("category_id", "=", self.env.ref("uom.uom_categ_length").id)
         ],
-        help="UoM for height",
+        help="UoM for length",
         default=lambda self: self.env[
             "product.template"
         ]._get_length_uom_id_from_ir_config_parameter(),

--- a/stock_storage_type/views/stock_storage_category.xml
+++ b/stock_storage_type/views/stock_storage_category.xml
@@ -8,6 +8,13 @@
         <field name="model">stock.storage.category</field>
         <field name="inherit_id" ref="stock.stock_storage_category_form" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='max_weight']//parent::div" position="after">
+                <label for="max_height" />
+                <div class="o_row">
+                    <field name="max_height" class="oe_inline" />
+                    <field name="height_uom_id" class="oe_inline" />
+                </div>
+            </xpath>
             <notebook position="inside">
                 <page name="advanced" string="Advanced">
                     <group


### PR DESCRIPTION
Fixes `AttributeError: 'stock.quant.package' object has no attribute 'estimated_pack_weight_kg'`. 
That field was removed in https://github.com/OCA/stock-logistics-tracking/commit/d3d646d1fa529e10a333bbb0b3f2412a3f709344 
(cf. related PR: https://github.com/OCA/stock-logistics-tracking/pull/48)