### PR TITLE
[18.0][IMP] stock_picking_putaway_recompute: add unsafe way to recompute

### DIFF
--- a/stock_picking_putaway_recompute/models/stock_move_line.py
+++ b/stock_picking_putaway_recompute/models/stock_move_line.py
@@ -30,7 +30,11 @@ class StockMoveLine(models.Model):
 
     def _can_recompute_putaway(self):
         self.ensure_one()
-        return self.picking_id._can_recompute_putaway() and not self.picked
+        return self._can_recompute_putaway_unsafe() and not self.picked
+
+    def _can_recompute_putaway_unsafe(self):
+        self.ensure_one()
+        return self.picking_id._can_recompute_putaway()
 
     def _filtered_for_putaway_recompute(self) -> Self:
         """
@@ -40,6 +44,8 @@ class StockMoveLine(models.Model):
             - have their picking not printed (started)
             - have their picked field set
         """
+        if self.env.context.get("allow_unsafe_putaway_recompute"):
+            return self.filtered(lambda line: line._can_recompute_putaway_unsafe())
         return self.filtered(lambda line: line._can_recompute_putaway())
 
     def _check_all_lines_with_same_dest_package(self):
@@ -74,9 +80,7 @@ class StockMoveLine(models.Model):
         # Reset location destinations to their move destination
         # First, protect the field from recomputations as
         # value will be reaffected afterwards.
-        with to_recompute_lines.env.protecting(
-            ["location_dest_id"], to_recompute_lines
-        ):
+        with self.env.protecting(["location_dest_id"], to_recompute_lines):
             for line in to_recompute_lines:
                 line.location_dest_id = line.move_id.location_dest_id
         to_recompute_lines._apply_putaway_strategy()

--- a/stock_picking_putaway_recompute/tests/test_recompute_putaway.py
+++ b/stock_picking_putaway_recompute/tests/test_recompute_putaway.py
@@ -172,6 +172,25 @@ class TestRecomputePutaway(TransactionCase):
             self.sub_location_1, self.picking.move_line_ids.location_dest_id
         )
 
+    def test_recompute_putaway_unsafe(self):
+        """Check unsafe recompute putaway."""
+        self._create_picking()
+        self.picking.action_confirm()
+        self.assertFalse(
+            self.sub_location_2 in self.picking.move_line_ids.location_dest_id
+        )
+        self.picking.move_line_ids.picked = True
+        # Change the rule destination
+        self.rule.location_out_id = self.sub_location_2
+        # Use the context to recompute
+        self.picking.with_context(
+            allow_unsafe_putaway_recompute=True
+        ).action_recompute_putaways()
+        # Location has change despite the lines being picked
+        self.assertTrue(
+            self.sub_location_2 in self.picking.move_line_ids.location_dest_id
+        )
+
     def test_recompute_putaway_printed(self):
         """
         Create a single picking from Suppliers -> Stock


### PR DESCRIPTION
Only enforce the filtering of the lines when calling the action. When calling the private method only check the related picking type has the flag for recompute.