### PR TITLE
[18.0][IMP] stock_storage_type: add index on stock_location.computed_storage_category_id

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -21,6 +21,7 @@ class StockLocation(models.Model):
         string="Computed Storage Category",
         compute="_compute_computed_storage_category_id",
         store=True,
+        index="btree_not_null",
         recursive=True,
         help=(
             "This represents the Storage Category that will be used. It depends "


### PR DESCRIPTION
Better perf to compute the put-away when the number of locations is high.
It is needed especially since the rewrite of `<stock.storage.category>._domain_location_storage_category(...)` which is now using `computed_storage_category_id` directly [in its domain](https://github.com/OCA/stock-logistics-putaway/blob/ed194323ca435f43e6a7dcf3d961b1f6bd93095f/stock_storage_type/models/stock_storage_category.py#L154).