### PR TITLE
[FIX] stock_storage_type: allow to delete a package type

### DIFF
--- a/stock_storage_type/models/stock_storage_location_sequence.py
+++ b/stock_storage_type/models/stock_storage_location_sequence.py
@@ -8,7 +8,11 @@ class StockStorageLocationSequence(models.Model):
     _description = "Sequence of locations to put-away the package type"
     _order = "sequence,id"
 
-    package_type_id = fields.Many2one("stock.package.type", required=True)
+    package_type_id = fields.Many2one(
+        "stock.package.type",
+        required=True,
+        ondelete="cascade",
+    )
     sequence = fields.Integer(required=True)
     location_id = fields.Many2one(
         "stock.location",


### PR DESCRIPTION
Delete its configuration lines in cascade when the package type is deleted.

No need to delete each config lines before deleting the package type. Lines are accessed from the package type only, they are part of it. They should not block its deletion.

cc @lmignon @rousseldenis @TDu @mmequignon 