### PR TITLE
[IMP] stock_putaway_rule_product_handle: Update the sequence at rule creation

### DIFF
--- a/stock_putaway_rule_product_handle/models/__init__.py
+++ b/stock_putaway_rule_product_handle/models/__init__.py
@@ -1,2 +1,3 @@
 from . import product_template
 from . import product_product
+from . import stock_putaway_rule

--- a/stock_putaway_rule_product_handle/models/product_template.py
+++ b/stock_putaway_rule_product_handle/models/product_template.py
@@ -21,6 +21,8 @@ class ProductTemplate(models.Model):
         context = res.get("context")
         if not context:
             res["context"] = {
-                "invisible_handle": self.env.context.get("invisible_handle")
+                "from_product_form": True,
+                "invisible_handle": self.env.context.get("invisible_handle"),
             }
+        res["context"].update({"from_product_form": True})
         return res

--- a/stock_putaway_rule_product_handle/models/stock_putaway_rule.py
+++ b/stock_putaway_rule_product_handle/models/stock_putaway_rule.py
@@ -1,0 +1,53 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from collections import defaultdict
+
+from odoo import api, models
+
+
+class StockPutawayRule(models.Model):
+    _inherit = "stock.putaway.rule"
+
+    def _update_sequence_handle(self, vals_list):
+        """
+        This will update the value that is used for creation of putaway rules
+        from product form as all sequences will have the default value and are
+        not ordered (which is unwanted).
+        """
+        if self.env.context.get("from_product_form") and not self.env.context.get(
+            "dont_recompute_sequence"
+        ):
+            max_sequences = defaultdict(lambda: 0)
+            default_sequence = self._fields["sequence"].default
+            default_sequence = default_sequence if default_sequence else 0
+            product_ids = list()
+            for vals in vals_list:
+                product_ids.append(vals.get("product_id"))
+            # Get the max sequence per product
+            existing_rules = self.read_group(
+                [("product_id", "in", list(set(product_ids)))],
+                ["product_id", "sequence:max"],
+                ["product_id"],
+            )
+            for vals in vals_list:
+                vals_product_id = vals.get("product_id")
+                max_sequences[vals_product_id] = max(
+                    vals.get("sequence"), default_sequence
+                )
+                for product in existing_rules:
+                    product_id = product["product_id"][0]
+                    if product_id == vals_product_id:
+                        max_sequences[vals_product_id] = (
+                            max(product.get("sequence"), max_sequences[vals_product_id])
+                            + 1
+                        )
+                        break
+                vals["sequence"] = max_sequences[vals_product_id]
+                max_sequences[vals_product_id] += 1
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        self._update_sequence_handle(vals_list=vals_list)
+        result = super().create(vals_list)
+        return result

--- a/stock_putaway_rule_product_handle/tests/test_putaway_sequence.py
+++ b/stock_putaway_rule_product_handle/tests/test_putaway_sequence.py
@@ -1,0 +1,44 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests import Form
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class TestSequence(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+            }
+        )
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.stock_1 = cls.env["stock.location"].create(
+            {"name": "Stock 1", "location_id": cls.warehouse.lot_stock_id.id}
+        )
+        cls.stock_2 = cls.env["stock.location"].create(
+            {"name": "Stock 2", "location_id": cls.warehouse.lot_stock_id.id}
+        )
+
+    def test_sequence(self):
+        with Form(
+            self.env["stock.putaway.rule"].with_context(
+                default_product_id=self.product.id, from_product_form=True
+            )
+        ) as putaway_form:
+            putaway_form.location_in_id = self.warehouse.lot_stock_id
+            putaway_form.location_out_id = self.stock_1
+        putaway_0 = putaway_form.save()
+        with Form(
+            self.env["stock.putaway.rule"].with_context(
+                default_product_id=self.product.id, from_product_form=True
+            )
+        ) as putaway_form:
+            putaway_form.location_in_id = self.warehouse.lot_stock_id
+            putaway_form.location_out_id = self.stock_2
+        putaway_1 = putaway_form.save()
+
+        self.assertEqual(0, putaway_0.sequence)
+        self.assertEqual(1, putaway_1.sequence)


### PR DESCRIPTION

As the interface does not reflect exactly the order for two rules created without handle move (both at sequence == 0), we need to reorder the sequence.